### PR TITLE
update CI julia versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          #- '1.0'
+          - '1.6'
           - '1.9'
           - 'nightly'
         os:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
           #- '1.0'
           - '1.6'
           - '1.9'
-          - 'nightly'
+          #- 'nightly'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["Tamás Cserteg <cserteg.tamas@sztaki.hu>", "András Kovács <akovacs
 version = "1.0.0-DEV"
 
 [compat]
-julia = "1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Updating CI because:
- current julia LTS is 1.6
- there's no need to test on nightly (cf: https://discourse.julialang.org/t/why-do-packages-run-continuous-integration-tests-on-julia-nightly/101208/3