### PR TITLE
Upgrades and developments

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         version:
           #- '1.0'
-          - '1.6'
           - '1.9'
           #- 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 [compat]
 DataFrames = "1"
 JuMP = "1.4"
-Meshes = "0.32"
+Meshes = "0.34"
 PrettyTables = "2"
 julia = "1.6"
 Rotations = "1.5"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 [compat]
 DataFrames = "1"
 JuMP = "1.4"
-Meshes = "0.34"
+Meshes = "0.34,0.35"
 PrettyTables = "2"
 julia = "1.9"
 Rotations = "1.5"

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ DataFrames = "1"
 JuMP = "1.4"
 Meshes = "0.34"
 PrettyTables = "2"
-julia = "1.6"
+julia = "1.9"
 Rotations = "1.5"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The package is registered in the general registry, so it can be installed via ru
 ] add BlankLocalizationCore
 ```
 
+For the exaplanation on how the package works, please read through the [Example](https://csertegt3.github.io/BlankLocalizationCore.jl/stable/example/) page of the documentation.
+
 Note, that at least Julia 1.9 is required.
 If you are interested in using the package with older versions, please open an issue!
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ The documentation goes through a detailed example of the process while showing h
 The package is registered in the general registry, so it can be installed via running:
 
 ```julia
-]
-add BlankLocalizationCore
+] add BlankLocalizationCore
 ```
+
+Note, that at least Julia 1.9 is required.
+If you are interested in using the package with older versions, please open an issue!
 
 ## Design goals
 

--- a/docs/src/example.md
+++ b/docs/src/example.md
@@ -46,7 +46,7 @@ pzb = PartZero("back", [0,0,0], hcat([0, -1, 0], [0, 0, 1], [-1, 0, 0]))
 partzeros = [pzf, pzr, pzb]
 ```
 
-When constructing a part zero, a default `[0,0,0]` positions is set, as the goal of the optimization process is to find the values of those positions.
+When constructing a part zero, a default `[0,0,0]` position is set, as the goal of the optimization process is to find the values of those position.
 For more details see the docs of [`PartZero`](@ref).
 
 ## Machined features
@@ -252,10 +252,11 @@ A few parameters are needed for the optimization problem, passed to the object a
 These are:
 
 | Name (key) | Description | Suggested value | Required? |
-| --- | ---  | --- | --- |
+| :--- | :---  | --- | --- |
 | minAllowance | Minimum allowance that must be achieved even by the lowest value. | `0.1` | Required |
 | OptimizeForToleranceCenter | The default method is to optimize for the middle (center) of the tolerance fields. For debugging, one can set it to `false`, then the minimum allowance will be maximised (ignoring the `minAllowance` value). | `true` | Required |
 | UseTolerances | Also a debugging feature. Tolerance lower-upper values are added as active constraints on the distance of the corresponding features. This can be turned off with this flag. | `true` | Required |
+| SetPartZeroPosition | The position of each part zero can be set with this option. A vector of 3 long vectors is expected, that is matched with the number of part zeros. Empty vectors can be passed, if not all part zero positions should be set. For example setting this option to `[[], [], []]` for three part zeros will have no effect. `NaN` elements are ignored, which means that specific axes of part zeros can be set. For example `[[NaN, 150, Nan], [], []]` would only set the value of the Y axis of the first part zero, all others are unaffected. | | Optional |
 
 We need to load the JuMP package and also an optimizer.
 For the papers we used FICO Xpress, therefore here it will be used as well, thanks to the [Xpress.jl](https://github.com/jump-dev/Xpress.jl) package.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -34,9 +34,10 @@ The documentation goes through a detailed example of the process while showing h
 The package is registered in the general registry, so it can be installed via running:
 
 ```julia
-]
-add BlankLocalizationCore
+] add BlankLocalizationCore
 ```
+
+For the exaplanation on how the package works, please read through the [Example](@ref) page.
 
 ## Acknowledgements
 

--- a/src/BlankLocalizationCore.jl
+++ b/src/BlankLocalizationCore.jl
@@ -42,8 +42,10 @@ export  createjumpmodel,
         optimizeproblem!
 
 export  allowancetable,
+        minimumallowance,
         printallowancetable,
         tolerancetable,
+        toleranceerror,
         printtolerancetable
 
 export  genroughholes,

--- a/src/geometries.jl
+++ b/src/geometries.jl
@@ -332,7 +332,7 @@ mutable struct MultiOperationProblem
     holes::Vector{HoleLocalizationFeature}
     planes::Vector{PlaneLocalizationFeature}
     tolerances::Vector{Tolerance}
-    parameters::Dict{String,Real}
+    parameters::Dict{String,Any}
     opresult::OptimizationResult
 end
 

--- a/src/optimization.jl
+++ b/src/optimization.jl
@@ -184,6 +184,27 @@ function createjumpmodel(mop::MultiOperationProblem, optimizer; disable_string_n
         @objective(model, Max, minAllowance)
     end
 
+    # set part zeros if option is provided
+    if haskey(mop.parameters, "SetPartZeroPosition")
+        predef_partzeros = mop.parameters["SetPartZeroPosition"]
+        lpz = length(mop.partzeros)
+        lpdz = length(predef_partzeros)
+        if lpz == lpdz
+            # for each part zero
+            for i in pzr
+                # ignore elements that are empty
+                ith_pzpose = predef_partzeros[i]
+                isempty(ith_pzpose) && continue
+                for j in 1:3
+                    isnan(ith_pzpose[j]) && continue
+                    @constraint(model, pzpose[i, j] == ith_pzpose[j])
+                end
+            end
+        else
+            throw(DimensionMismatch("Length of `SetPartZeroPosition` ($lpdz) does not match number of part zeros ($lpz)!"))
+        end
+    end
+
     return model
 end
 

--- a/src/resultevaluation.jl
+++ b/src/resultevaluation.jl
@@ -104,6 +104,11 @@ function computeallowance(::IsFreeForm, plane::PlaneLocalizationFeature)
         zdistance = zdist, axallowance = axallowance)
 end
 
+"""
+    allowancetable(mop::MultiOperationProblem)
+
+Generate the allowance table for a given `mop` to examine the allowance for each feature.
+"""
 function allowancetable(mop::MultiOperationProblem)
     df = DataFrame(name=String[], partzeroname=String[], machinedx=FON[], machinedy=FON[],
         machinedz=FON[], roughx=FON[], roughy=FON[], roughz=FON[], machinedr=FON[],
@@ -138,6 +143,20 @@ function allowancetable(mop::MultiOperationProblem)
     return df
 end
 
+"""
+    minimumallowance(mop::MultiOperationProblem)
+
+Calculate the minimum allowances (radial and axial) for the given `mop`.
+Calls [`allowancetable`](@ref) under the hood.
+"""
+minimumallowance(mop::MultiOperationProblem) = minimumallowance(allowancetable(mop))
+
+"""
+    minimumallowance(allowancedb)
+
+Calculate the minimum allowances (radial and axial) for the given allowance database
+(computed by [`allowancetable`](@ref)).
+"""
 function minimumallowance(allowancedb)
     radial = minimum(filter(x->!isnothing(x), allowancedb.rallowance))
     axial = minimum(filter(x->!isnothing(x), allowancedb.axallowance))
@@ -173,6 +192,11 @@ function printallowancetable(df::DataFrame; title = "", printstat=true, fname=""
 
 end
 
+"""
+    tolerancetable(mop::MultiOperationProblem)
+
+Generate the tolerance table for a given `mop` to examine the tolerances.
+"""
 function tolerancetable(mop::MultiOperationProblem)
     """modify a tolerance's names based on if the features are rough or machined"""
     function fnameplusrORm(t)
@@ -206,7 +230,23 @@ function tolerancetable(mop::MultiOperationProblem)
     return df
 end
 
-function avgreltolerror(tolerancedb)
+"""
+    toleranceerror(mop::MultiOperationProblem)
+
+Calculate the average relative tolerance error for the given `mop`.
+Calls [`tolerancetable`](@ref) under the hood.
+Gives the result in the 0-100 % range.
+"""
+toleranceerror(mop::MultiOperationProblem) = toleranceerror(tolerancetable(mop))
+
+"""
+    toleranceerror(tolerancedb)
+
+Calculate the average relative tolerance error for the given tolerance database
+(computed by [`tolerancetable`](@ref)).
+Gives the result in the 0-100 % range.
+"""
+function toleranceerror(tolerancedb)
     return sum(abs.(tolerancedb.tolerancefield))/nrow(tolerancedb)
 end
 
@@ -229,7 +269,7 @@ function printtolerancetable(df::DataFrame; title = "", printstat=true, fname=""
     end
     if printstat
         newtitle = string("Tolerance table", title, " avgabsreltolerror: ",
-        @sprintf("%.1f", avgreltolerror(df)), "%")
+        @sprintf("%.1f", toleranceerror(df)), "%")
     else
         newtitle = string("Tolerance table", title)
     end

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -58,7 +58,7 @@ function transformmachinedgeoms(lf::LocalizationFeature)
     R = pz.rotation
     rot = RotMatrix{3}(R)
     # again, I'm not sure about why the inverse...
-    fr = Rotate(inv(rot))
+    fr = Rotate(rot)
     ft = Translate(pz.position...)
     geom = visualizationgeometry(lf.machined)
     geom2 = fr(geom)


### PR DESCRIPTION
Small improvements, including:
- 8873e03 (closes #13 )
- 5f04a86 (closes #17)
- 7c3f64c - add option for setting part zeros to fixed poses
- f146523 - document and implement minimum allowance and tolerance error calculating functions (closes #11)

Julia 1.6 support is dropped, as Meshes.jl now uses package extension, that was introduced in julia 1.9.